### PR TITLE
Updates

### DIFF
--- a/PHPCodeGenerator.js
+++ b/PHPCodeGenerator.js
@@ -393,7 +393,7 @@ define(function (require, exports, module) {
                     terms.push(visibility);
                 }
                 terms.push("function __construct()");
-                codeWriter.writeLine(terms.join(" ") + " {");
+                codeWriter.writeLine(terms.join(" ") + "\n{");
                 codeWriter.writeLine("}");
             }
         }
@@ -491,7 +491,7 @@ define(function (require, exports, module) {
             if (skipBody === true || _.contains(_modifiers, "abstract")) {
                 codeWriter.writeLine(terms.join(" ") + ";");
             } else {
-                codeWriter.writeLine(terms.join(" ") + " {");
+                codeWriter.writeLine(terms.join(" ") + "\n{");
                 codeWriter.indent();
 
                 //spacification
@@ -591,7 +591,7 @@ define(function (require, exports, module) {
             terms.push(_method.name + "(" + paramTerms.join(", ") + ")");
 
             // body
-            codeWriter.writeLine(terms.join(" ") + " {");
+            codeWriter.writeLine(terms.join(" ") + "\n{");
             codeWriter.indent();
 
             codeWriter.writeLine("// TODO implement here");
@@ -643,7 +643,7 @@ define(function (require, exports, module) {
                     return e.name;
                 }).join(", "));
         }
-        codeWriter.writeLine(terms.join(" ") + " {");
+        codeWriter.writeLine(terms.join(" ") + "\n{");
         codeWriter.writeLine();
         codeWriter.indent();
 
@@ -740,7 +740,7 @@ define(function (require, exports, module) {
                     return e.name;
                 }).join(", "));
         }
-        codeWriter.writeLine(terms.join(" ") + " {");
+        codeWriter.writeLine(terms.join(" ") + "\n{");
         codeWriter.writeLine();
         codeWriter.indent();
 
@@ -811,7 +811,7 @@ define(function (require, exports, module) {
         terms.push("enum");
         terms.push(elem.name);
 
-        codeWriter.writeLine(terms.join(" ") + " {");
+        codeWriter.writeLine(terms.join(" ") + "\n{");
         codeWriter.indent();
 
         // Literals
@@ -851,7 +851,7 @@ define(function (require, exports, module) {
         terms.push("@interface");
         terms.push(elem.name);
 
-        codeWriter.writeLine(terms.join(" ") + " {");
+        codeWriter.writeLine(terms.join(" ") + "\n{");
         codeWriter.writeLine();
         codeWriter.indent();
 

--- a/PHPCodeGenerator.js
+++ b/PHPCodeGenerator.js
@@ -168,12 +168,14 @@ define(function (require, exports, module) {
      */
     PHPCodeGenerator.prototype.getVisibility = function (elem) {
         switch (elem.visibility) {
-            case UML.VK_PUBLIC:
-                return "public";
-            case UML.VK_PROTECTED:
-                return "protected";
-            case UML.VK_PRIVATE:
-                return "private";
+        case UML.VK_PACKAGE:
+            return "";
+        case UML.VK_PUBLIC:
+            return "public";
+        case UML.VK_PROTECTED:
+            return "protected";
+        case UML.VK_PRIVATE:
+            return "private";
         }
         return null;
     };

--- a/PHPCodeGenerator.js
+++ b/PHPCodeGenerator.js
@@ -723,12 +723,6 @@ define(function (require, exports, module) {
         // Doc
         this.writeDoc(codeWriter, elem.documentation, options);
 
-        // Modifiers
-        var visibility = this.getVisibility(elem);
-        if (visibility) {
-            terms.push(visibility);
-        }
-
         // Interface
         terms.push("interface");
         terms.push(elem.name);

--- a/PHPCodeGenerator.js
+++ b/PHPCodeGenerator.js
@@ -792,26 +792,30 @@ define(function (require, exports, module) {
      * @param {Object} options
      */
     PHPCodeGenerator.prototype.writeEnum = function (codeWriter, elem, options) {
-        var i, len, terms = [];
+        var i, len, terms = [],
+            literals = [];
         // Doc
         this.writeDoc(codeWriter, elem.documentation, options);
 
-        // Modifiers
-        var visibility = this.getVisibility(elem);
-        if (visibility) {
-            terms.push(visibility);
-        }
         // Enum
-        terms.push("enum");
+        terms.push("class");
         terms.push(elem.name);
+        terms.push("extends");
+        terms.push(SEPARATE_NAMESPACE + "SplEnum");
 
         codeWriter.writeLine(terms.join(" ") + "\n{");
         codeWriter.indent();
 
         // Literals
         for (i = 0, len = elem.literals.length; i < len; i++) {
-            codeWriter.writeLine(elem.literals[i].name + (i < elem.literals.length - 1 ? "," : ""));
+            literals.push("const");
+            literals.push(elem.literals[i].name);
+            literals.push("=");
+            literals.push(i);
+            literlas.push(";");
         }
+
+        codeWriter.writeLine(literals.join(" ") + "\n");
 
         codeWriter.outdent();
         codeWriter.writeLine("}");


### PR DESCRIPTION
There's a few things here that I wanted to offer to help.
1. PSR2 standards ask for newlines before opening braces, and as it is generally the accepted standard, I've done this.
2. In PHP, interfaces don't have a visibility keyword.
3. Sadly, in PHP, enum doesn't exist, but there is a core class to emulate it.
4. Linked to an issue I spotted (but didn't log in favour of fixing it), there should be allowance to not set a visibility, and as 'package' isn't a PHP thing, it maps nicely.

I hope this is helpful, it certainly is for me using this package.
